### PR TITLE
Added random ISO date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+## 1.0.1 - Add date format: ISO 8601
 ## 1.0.0 - First Release
 * Support for basic set of random data

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This package is entirely based around the superb [Chance](http://chancejs.com/) 
 - **Street**: random:street
 - **U.S. ZIP Code**: random:zip
 - **Date**: random:date
+- **Date (ISO 8601)**: random:isodate
 - **Hammertime**: random:hammertime
 - **Month**: random:month
 - **Year**: random:year

--- a/lib/random.coffee
+++ b/lib/random.coffee
@@ -86,6 +86,7 @@ module.exports = AtomRandom =
       'random:street': => @random(chance.street())
       'random:zip': => @random(chance.zip())
       'random:date': => @random(chance.date())
+      'random:isodate': => @random(chance.date().toISOString())
       'random:hammertime': => @random(chance.hammertime())
       'random:month': => @random(chance.month())
       'random:year': => @random(chance.year())

--- a/menus/random.cson
+++ b/menus/random.cson
@@ -208,8 +208,8 @@ menu: [
       }
       
       {
-        label: "Random Date ISO 8601"
-        command: "random:iso8601"
+        label: "Random Date (ISO 8601)"
+        command: "random:isodate"
       }
       {
         label: "Random Hammertime"

--- a/menus/random.cson
+++ b/menus/random.cson
@@ -206,6 +206,11 @@ menu: [
         label: "Random Date"
         command: "random:date"
       }
+      
+      {
+        label: "Random Date ISO 8601"
+        command: "random:iso8601"
+      }
       {
         label: "Random Hammertime"
         command: "random:hammertime"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "random",
   "main": "./lib/random",
-  "version": "0.1.5",
+  "version": "1.0.1",
   "description": "Generates several random data types, for use as passwords or as test data.",
   "keywords": [
     "random",
@@ -61,6 +61,7 @@
       "random:street",
       "random:zip",
       "random:date",
+      "random:isodate",
       "random:hammertime",
       "random:month",
       "random:year",

--- a/spec/random-data-spec.coffee
+++ b/spec/random-data-spec.coffee
@@ -208,8 +208,8 @@ describe "Random Data", ->
     spyOn(chance, 'date').andReturn('Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)')
     dataTest 'date', 'Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)'
   it "inserts random iso date", ->
-    spyOn(chance, 'isodate').andReturn('2016-01-15T08:06:14.000Z')
-    dataTest 'isodate', 'Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)'
+    spyOn(chance, 'isodate').andReturn('Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)')
+    dataTest 'isodate', '2016-01-15T08:06:14.000Z'
   it "inserts random hammertime", ->
     spyOn(chance, 'hammertime').andReturn('2610322083978')
     dataTest 'hammertime', '2610322083978'

--- a/spec/random-data-spec.coffee
+++ b/spec/random-data-spec.coffee
@@ -208,7 +208,7 @@ describe "Random Data", ->
     spyOn(chance, 'date').andReturn('Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)')
     dataTest 'date', 'Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)'
   it "inserts random iso date", ->
-    spyOn(chance, 'date').andReturn(new Date(Date.UTC(2106, 0, 15, 8, 6, 14)))
+    spyOn(chance, 'date').andReturn(new Date(Date.UTC(2016, 0, 15, 8, 6, 14)))
     dataTest 'isodate', '2016-01-15T08:06:14.000Z'
   it "inserts random hammertime", ->
     spyOn(chance, 'hammertime').andReturn('2610322083978')

--- a/spec/random-data-spec.coffee
+++ b/spec/random-data-spec.coffee
@@ -207,6 +207,9 @@ describe "Random Data", ->
   it "inserts random date", ->
     spyOn(chance, 'date').andReturn('Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)')
     dataTest 'date', 'Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)'
+  it "inserts random iso date", ->
+    spyOn(chance, 'isodate').andReturn('2016-01-15T08:06:14.000Z')
+    dataTest 'isodate', 'Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)'
   it "inserts random hammertime", ->
     spyOn(chance, 'hammertime').andReturn('2610322083978')
     dataTest 'hammertime', '2610322083978'

--- a/spec/random-data-spec.coffee
+++ b/spec/random-data-spec.coffee
@@ -208,7 +208,7 @@ describe "Random Data", ->
     spyOn(chance, 'date').andReturn('Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)')
     dataTest 'date', 'Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)'
   it "inserts random iso date", ->
-    spyOn(chance, 'date').andReturn(new Date(Date.UTC(2106, 1, 15, 8, 6, 14)))
+    spyOn(chance, 'date').andReturn(new Date(Date.UTC(2106, 0, 15, 8, 6, 14)))
     dataTest 'isodate', '2016-01-15T08:06:14.000Z'
   it "inserts random hammertime", ->
     spyOn(chance, 'hammertime').andReturn('2610322083978')

--- a/spec/random-data-spec.coffee
+++ b/spec/random-data-spec.coffee
@@ -208,7 +208,7 @@ describe "Random Data", ->
     spyOn(chance, 'date').andReturn('Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)')
     dataTest 'date', 'Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)'
   it "inserts random iso date", ->
-    spyOn(chance, 'date').andReturn('Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)')
+    spyOn(chance, 'date').andReturn(new Date(Date.UTC(2106, 1, 15, 8, 6, 14)))
     dataTest 'isodate', '2016-01-15T08:06:14.000Z'
   it "inserts random hammertime", ->
     spyOn(chance, 'hammertime').andReturn('2610322083978')

--- a/spec/random-data-spec.coffee
+++ b/spec/random-data-spec.coffee
@@ -208,7 +208,7 @@ describe "Random Data", ->
     spyOn(chance, 'date').andReturn('Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)')
     dataTest 'date', 'Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)'
   it "inserts random iso date", ->
-    spyOn(chance, 'isodate').andReturn('Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)')
+    spyOn(chance, 'date').andReturn('Fri Jan 15 2106 08:06:14 GMT+0000 (GMT Standard Time)')
     dataTest 'isodate', '2016-01-15T08:06:14.000Z'
   it "inserts random hammertime", ->
     spyOn(chance, 'hammertime').andReturn('2610322083978')


### PR DESCRIPTION
Add functionality to generate a random date in ISO 8601 format. 
_Same result as `random:date` except it also calls `toISOString()`_
1.  Added  menu entry `Random/Random Date (ISO 8601)
2.  Added command `random:isodate`
3. Updated  version info

See: RichardSlater/atom-random#2
